### PR TITLE
Deprecating default configuration values.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "org.seekerwing"
-version = "0.2"
+version = "0.1"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "org.seekerwing"
-version = "0.1"
+version = "0.2"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageFetcherConfiguration.kt
+++ b/src/main/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageFetcherConfiguration.kt
@@ -5,20 +5,29 @@ package org.seekerwing.aws.sqsconsumer.configuration
  * [MessageFetcherKt.fetchMessage][org.seekerwing.aws.sqsconsumer.sqs.MessageFetcherKt.fetchMessage].
  *
  * [maximumNumberOfMessages] indicates how many messages should be fetched from the queue in a single request;
- * valid values: 1 to 10; default value: 10.
+ * valid values: 1 to 10;.
  *
  * [waitTimeSeconds] indicates duration (in seconds) for which the call waits for a message to arrive in the queue
  * before returning. If a message is available, the call returns sooner than [waitTimeSeconds]. If no messages are
  * available and the wait time expires, the call returns successfully with an empty list of messages. It is recommended
  * that the value be set to the maximum possible value to reduces costs when there are no messages present in the queue;
- * valid values: 0 to 20; default value: 20.
+ * valid values: 0 to 20;.
  *
  * [visibilityTimeoutSeconds] indicates duration (in seconds) that the message is hidden from subsequent fetch requests
  * after being fetched;
- * valid values: 0 to 43200; default value: 30.
+ * valid values: 0 to 43200;.
  */
 data class MessageFetcherConfiguration(
-    val maximumNumberOfMessages: Int = 10,
-    val waitTimeSeconds: Int = 20,
-    val visibilityTimeoutSeconds: Int = 30
-)
+    val maximumNumberOfMessages: Int,
+    val waitTimeSeconds: Int,
+    val visibilityTimeoutSeconds: Int
+) {
+
+    @Deprecated(
+        message = "Please specify values explicitly",
+        replaceWith = ReplaceWith(
+            expression = "MessageFetcherConfiguration(/* TODO revisit parameters*/ maximumNumberOfMessages = 10, " +
+                    "waitTimeSeconds = 20, visibilityTimeoutSeconds = 30)"))
+    @Suppress("MagicNumber")
+    constructor() : this (10, 20, 30)
+}

--- a/src/main/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageProviderConfiguration.kt
+++ b/src/main/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageProviderConfiguration.kt
@@ -20,6 +20,14 @@ import org.seekerwing.aws.sqsconsumer.model.Queue
  */
 data class MessageProviderConfiguration(
     val queue: Queue,
-    val messageFetcherConfiguration: MessageFetcherConfiguration = MessageFetcherConfiguration(),
+    val messageFetcherConfiguration: MessageFetcherConfiguration,
     val parallelism: Int = 1
-)
+) {
+
+    @Deprecated(
+        message = "Please specify messageFetcherConfiguration explicitly",
+        replaceWith = ReplaceWith("MessageProviderConfiguration(" +
+                "queue, /* TODO revisit parameter*/ MessageFetcherConfiguration(), parallelism)")
+    )
+    constructor(queue: Queue, parallelism: Int = 1) : this(queue, MessageFetcherConfiguration(), parallelism)
+}

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageFetcherConfigurationTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageFetcherConfigurationTest.kt
@@ -8,21 +8,18 @@ internal class MessageFetcherConfigurationTest {
     @Test
     fun getMaximumNumberOfMessages() {
         assertEquals(10, MessageFetcherConfiguration().maximumNumberOfMessages)
-        assertEquals(42, MessageFetcherConfiguration(maximumNumberOfMessages = 42).maximumNumberOfMessages)
         assertEquals(24, MessageFetcherConfiguration(24, 42, 7).maximumNumberOfMessages)
     }
 
     @Test
     fun getWaitTimeSeconds() {
         assertEquals(20, MessageFetcherConfiguration().waitTimeSeconds)
-        assertEquals(42, MessageFetcherConfiguration(waitTimeSeconds = 42).waitTimeSeconds)
         assertEquals(24, MessageFetcherConfiguration(7, 24, 42).waitTimeSeconds)
     }
 
     @Test
     fun getVisibilityTimeoutSeconds() {
         assertEquals(30, MessageFetcherConfiguration().visibilityTimeoutSeconds)
-        assertEquals(42, MessageFetcherConfiguration(visibilityTimeoutSeconds = 42).visibilityTimeoutSeconds)
         assertEquals(24, MessageFetcherConfiguration(42, 7, 24).visibilityTimeoutSeconds)
     }
 }

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageProviderConfigurationTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/configuration/MessageProviderConfigurationTest.kt
@@ -30,6 +30,11 @@ internal class MessageProviderConfigurationTest {
         assertEquals(PARALLELISM, MessageProviderConfiguration(queue, fetcherConfiguration, PARALLELISM).parallelism)
     }
 
+    @Test
+    fun getDefaultConfiguration() {
+        assertEquals(10, MessageProviderConfiguration(queue).messageFetcherConfiguration.maximumNumberOfMessages)
+    }
+
     companion object {
         const val PARALLELISM = 42
     }

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/messageprovider/MultipleQueueBasedMessageProviderTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/messageprovider/MultipleQueueBasedMessageProviderTest.kt
@@ -21,7 +21,7 @@ internal class MultipleQueueBasedMessageProviderTest {
     @Test
     @DisplayName("validate that provideMessages invokes launchMessageFetcher for each queue in MessageProviderConfiguration N (parallelism) times")
     fun provideMessage() = runBlockingTest {
-        val fetcherConfiguration = MessageFetcherConfiguration()
+        val fetcherConfiguration = MessageFetcherConfiguration(10, 20, 30)
         val queue1: Queue = mockk()
         val providerConfiguration1 = MessageProviderConfiguration(queue1, fetcherConfiguration, 2)
         val queue2: Queue = mockk()

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/messageprovider/SingleQueueBasedMessageProviderTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/messageprovider/SingleQueueBasedMessageProviderTest.kt
@@ -22,7 +22,7 @@ internal class SingleQueueBasedMessageProviderTest {
     @DisplayName("validate that provideMessages invokes launchMessageFetcher N (parallelism) times")
     fun provideMessage() = runBlockingTest {
         val queue: Queue = mockk()
-        val fetcherConfiguration = MessageFetcherConfiguration()
+        val fetcherConfiguration = MessageFetcherConfiguration(10, 20, 30)
         val providerConfiguration = MessageProviderConfiguration(queue, fetcherConfiguration, 2)
 
         mockkStatic("org.seekerwing.aws.sqsconsumer.sqs.MessageFetcherLauncherKt")

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/sqs/MessageFetcherLauncherTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/sqs/MessageFetcherLauncherTest.kt
@@ -33,7 +33,7 @@ internal class MessageFetcherLauncherTest : CoroutineScope {
     @Test
     @DisplayName("validate that launchMessageFetcher invokes Queue.fetchMessage and Channel.send each Message")
     fun launchMessageFetcher() {
-        val fetcherConfiguration = MessageFetcherConfiguration()
+        val fetcherConfiguration = MessageFetcherConfiguration(10, 20, 30)
         val providerConfiguration = MessageProviderConfiguration(queue, fetcherConfiguration)
 
         mockkStatic("org.seekerwing.aws.sqsconsumer.sqs.MessageFetcherKt")

--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/sqs/MessageFetcherTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/sqs/MessageFetcherTest.kt
@@ -50,7 +50,7 @@ internal class MessageFetcherTest {
         }
         val queueContext = QueueContext(messageProcessor)
         val queue = Queue(sqsAsyncClient, QUEUE_URL, queueContext)
-        val receiveMessage = queue.fetchMessage(MessageFetcherConfiguration())
+        val receiveMessage = queue.fetchMessage(MessageFetcherConfiguration(10, 20, 30))
 
         assertEquals(queueContext, queue.queueContext)
         assertEquals(listOf(message), receiveMessage)


### PR DESCRIPTION
Default configuration values can lead to unintended consequences. E.g.
the default visibility timeout overrides the queue-wide timeout. If the
message processing takes more than 10 seconds, the message gets either
put in DLQ or will be processed again. While this is not wrong behavior,
having to explicity set these values, increases the awareness of how SQS
behaves.

This is change is not backwards compatible.