### PR TITLE
Fixes flakey coroutine unit test

### DIFF
--- a/src/test/kotlin/org/seekerwing/aws/sqsconsumer/SqsQueueConsumerTest.kt
+++ b/src/test/kotlin/org/seekerwing/aws/sqsconsumer/SqsQueueConsumerTest.kt
@@ -25,8 +25,8 @@ internal class SqsQueueConsumerTest {
         coEvery { messageProvider.provideMessages(any<CoroutineScope>()) } returns receiveChannel
         coEvery { messageConsumer.launchConsumer(any<CoroutineScope>(), eq(receiveChannel)) } returns Unit
 
-        sqsQueueConsumer.start()
-
+        val job = sqsQueueConsumer.start()
+        job.join()
         sqsQueueConsumer.stop()
 
         coVerify(exactly = 1) { messageProvider.provideMessages(any<CoroutineScope>()) }


### PR DESCRIPTION
Fixes flakey unit test where an invoked coroutine is not waited for before testing actions